### PR TITLE
Added the Tabletop Sim (TTS) deck list option

### DIFF
--- a/plugins/pokemon/deck_formats.py
+++ b/plugins/pokemon/deck_formats.py
@@ -1,3 +1,5 @@
+import json
+from collections import Counter
 from re import compile
 from enum import Enum
 from typing import Callable, Tuple
@@ -49,12 +51,50 @@ def parse_limitless(deck_text: str, handle_card: Callable) -> None:
 
     parse_deck_helper(deck_text, handle_card, is_limitless_line, extract_limitless_card_data)
 
+def parse_pkmtts(deck_text: str, handle_card: Callable) -> None:
+    # pokemoncard.io export: a JSON array of strings, one entry per physical
+    # card copy, formatted as '{set_id}-{card_no}' (plus a leading export
+    # header string, which is ignored). There's no per-line structure here,
+    # so this doesn't go through parse_deck_helper.
+    code_pattern = compile(r'^([a-zA-Z0-9]+)-(\d+)$')
+
+    try:
+        data = json.loads(deck_text)
+    except json.JSONDecodeError as e:
+        raise ValueError(f'Could not parse pkmtts export as JSON: {e}')
+
+    codes = [entry for entry in data if isinstance(entry, str) and code_pattern.match(entry)]
+    counts = Counter(codes)
+
+    error_lines = []
+    index = 0
+    for code, quantity in counts.items():
+        index = index + 1
+
+        match = code_pattern.match(code)
+        set_id = match.group(1)
+        card_no = match.group(2)
+        name = ''  # pkmtts.io export doesn't include card names
+
+        parts = [f'Index: {index}', f'quantity: {quantity}', f'set: {set_id}', f'card number: {card_no}']
+        print(', '.join(parts))
+        try:
+            handle_card(index, name, set_id, card_no, quantity)
+        except Exception as e:
+            print(f'Error: {e}')
+            error_lines.append((code, e))
+
+    if len(error_lines) > 0:
+        print(f'Errors: {error_lines}')
+
 class DeckFormat(str, Enum):
     LIMITLESS = 'limitless'
+    PKMTTS = 'pkmtts'
 
 def parse_deck(deck_text: str, format: DeckFormat, handle_card: Callable) -> None:
     if format == DeckFormat.LIMITLESS:
         return parse_limitless(deck_text, handle_card)
+    elif format == DeckFormat.PKMTTS:
+        return parse_pkmtts(deck_text, handle_card)
     else:
         raise ValueError('Unrecognized deck format.')
-

--- a/plugins/pokemon/fetch.py
+++ b/plugins/pokemon/fetch.py
@@ -7,10 +7,16 @@ REPO_ROOT = path.abspath(path.join(path.dirname(__file__), '..', '..'))
 sys.path.insert(0, REPO_ROOT)
 
 from plugins.pokemon.deck_formats import DeckFormat, parse_deck
-from plugins.pokemon.limitless import get_handle_card
-from utilities import configure_console_encoding, ensure_directory
+from plugins.pokemon.limitless import get_handle_card as get_limitless_handle_card
+from plugins.pokemon.pkmtts import get_handle_card as get_pkmtts_handle_card
+from utilities import ensure_directory
 
 front_directory = path.join(REPO_ROOT, 'game', 'front')
+
+HANDLE_CARD_GETTERS = {
+    DeckFormat.LIMITLESS: get_limitless_handle_card,
+    DeckFormat.PKMTTS: get_pkmtts_handle_card,
+}
 
 @command()
 @argument('deck_path')
@@ -22,11 +28,12 @@ def cli(deck_path: str, format: DeckFormat):
         print(f'{deck_path} is not a valid file.')
         return
 
+    get_handle_card = HANDLE_CARD_GETTERS[format]
+
     with open(deck_path, 'r') as deck_file:
         deck_text = deck_file.read()
 
         parse_deck(deck_text, format, get_handle_card(front_directory))
 
 if __name__ == '__main__':
-    configure_console_encoding()
     cli()

--- a/plugins/pokemon/pkmtts.py
+++ b/plugins/pokemon/pkmtts.py
@@ -1,0 +1,74 @@
+from os import path
+from requests import Session
+from requests.exceptions import HTTPError
+from time import sleep
+import filetype
+
+# PokemonCard.io serves two versions of each card image: a standard PNG and
+# a larger, higher-quality JPG (linked as "Image High Res" on card pages).
+POKEMONCARD_IO_HIRES_URL_TEMPLATE = 'https://images.pokemoncard.io/images/{set_id}/{set_id}-{card_no}_hiresopt.jpg'
+POKEMONCARD_IO_STANDARD_URL_TEMPLATE = 'https://images.pokemoncard.io/images/{set_id}/{set_id}-{card_no}.png'
+
+session = Session()
+
+_failed_hires = set()
+
+def request_pkmtts(url: str):
+    r = session.get(url, headers = {'user-agent': 'silhouette-card-maker/0.1', 'accept': '*/*'})
+
+    # Check for 2XX response code
+    r.raise_for_status()
+
+    sleep(0.075)
+
+    return r
+
+def fetch_card(
+    index: int,
+    quantity: int,
+    set_id: str,
+    card_number: str,
+    front_img_dir: str,
+):
+    card_art = None
+
+    # Try the hi-res version first
+    if set_id not in _failed_hires:
+        try:
+            url = POKEMONCARD_IO_HIRES_URL_TEMPLATE.format(set_id=set_id, card_no=card_number)
+            card_art = request_pkmtts(url).content
+        except HTTPError:
+            _failed_hires.add(set_id)
+
+    # Fall back to the standard-resolution PNG
+    if card_art is None:
+        try:
+            url = POKEMONCARD_IO_STANDARD_URL_TEMPLATE.format(set_id=set_id, card_no=card_number)
+            card_art = request_pkmtts(url).content
+        except HTTPError as e:
+            raise Exception(f'Failed to fetch card (set: {set_id}, number: {card_number}): {e}')
+
+    file_ext = filetype.guess(card_art).extension
+
+    # pkmtts exports don't include card names, so the filename is just
+    # index + copy number, matching limitless.py's index/counter scheme
+    # minus the name segment.
+    for counter in range(quantity):
+        image_path = path.join(front_img_dir, f'{str(index)}{str(counter + 1)}.{file_ext}')
+
+        with open(image_path, 'wb') as f:
+            f.write(card_art)
+
+def get_handle_card(
+    front_img_dir: str,
+):
+    def configured_fetch_card(index: int, card_name: str, set_id: str, card_number: str, quantity: int = 1):
+        fetch_card(
+            index,
+            quantity,
+            set_id,
+            card_number,
+            front_img_dir
+        )
+
+    return configured_fetch_card


### PR DESCRIPTION
Created a new option for the Pokemon plugin that uses the Tabletop Simulator (TTS) deck list export from pokemoncard.io to pull card images. Instead of using direct card names, this uses set codes and card numbers to pull accurate images. Tested using both base set and the most meta decks. It pulls high rez images first, and if it can't find any, it'll use the low rez option. 

Example deck list:
["Exported from https://pokemoncard.io","sv8pt5-4","sv8pt5-4","sv8pt5-71","sv8pt5-71","sv8pt5-71","sv8pt5-71","sv8pt5-72","sv8pt5-72","sv8pt5-72","sv8pt5-72","sv6-130","sv6-130","sv6-130","sv6pt5-38","me3-62","me2-14","sv8pt5-44","sv8pt5-44","sv5-144","sv5-144","sv5-144","sv5-144","me3-71","me3-71","me3-71","me3-71","sv6pt5-61","sv6pt5-61","me2pt5-198","me2pt5-198","me2pt5-198","me2pt5-198","me1-131","me1-131","me1-131","me1-131","sv6-165","me1-127","me2pt5-210","me2pt5-183","me2pt5-183","me2pt5-183","sv7-133","sv7-133","sv7-133","me2-87","me3-76","me1-119","me1-119","me1-119","me1-119","sv6pt5-98","sv6pt5-98","sv6pt5-98","sv3-230","sv3-230","sv3-230","sv3pt5-207","sv3pt5-207","sv3pt5-207"]